### PR TITLE
Adding try/catch to TraceContext 

### DIFF
--- a/Plugin/CanaryTracer.cs
+++ b/Plugin/CanaryTracer.cs
@@ -39,7 +39,16 @@ namespace Rappen.CDS.Canary
         /// <param name="service">Service used if convertqueries is true, may be null if not used.</param>
         public static void TraceContext(this ITracingService tracingservice, IExecutionContext context, bool parentcontext, bool attributetypes, bool convertqueries, bool expandcollections, IOrganizationService service)
         {
-            tracingservice.TraceContext(context, parentcontext, attributetypes, convertqueries, expandcollections, service, 1);
+            try
+            {
+                tracingservice.TraceContext(context, parentcontext, attributetypes, convertqueries, expandcollections,
+                    service, 1);
+            }
+            catch (Exception ex)
+            {
+                tracingservice.Trace("--- Exception while trying to TraceContext ---");
+                tracingservice.Trace($"Message : {ex.Message}");
+            }
         }
 
         private static void TraceContext(this ITracingService tracingservice, IExecutionContext context, bool parentcontext, bool attributetypes, bool convertqueries, bool expandcollections, IOrganizationService service, int depth)


### PR DESCRIPTION
Adding try/catch to TraceContext as we have seen SystemFormat exception (_Input string was not in a correct format_). on a Production CRM 2016 environment when using the CanaryTracer. 

That particular bug seemed to have to do with "description" field in emails at depth 2 (plugin triggers another plugin).
I wanted to get deeper into that bug to see if it had to do with the SDK but haven't had time to do so for now so I bypassed it like this with try/catch.